### PR TITLE
Update 08.sentiment-analysis-with-bert.ipynb

### DIFF
--- a/08.sentiment-analysis-with-bert.ipynb
+++ b/08.sentiment-analysis-with-bert.ipynb
@@ -116,7 +116,7 @@
         "\n",
         "*Label* = *NotNext*\n",
         "\n",
-        "The training corpus was comprised of two entries: [Toronto Book Corpus](https://arxiv.org/abs/1506.06724) (800M words) and English Wikipedia (2,500M words). While the original Transformer has an encoder (for reading the input) and a decoder (that makes the prediction), BERT uses only the decoder.\n",
+        "The training corpus was comprised of two entries: [Toronto Book Corpus](https://arxiv.org/abs/1506.06724) (800M words) and English Wikipedia (2,500M words). While the original Transformer has an encoder (for reading the input) and a decoder (that makes the prediction), BERT uses only the encoder.\n",
         "\n",
         "BERT is simply a pre-trained stack of Transformer Encoders. How many Encoders? We have two versions - with 12 (BERT base) and 24 (BERT Large).\n",
         "\n",


### PR DESCRIPTION
Bert uses only the encoders from transformers architecture, there was a typo

Earlier - While the original Transformer has an encoder (for reading the input) and a decoder (that makes the prediction), BERT uses only the decoder.

changed -  While the original Transformer has an encoder (for reading the input) and a decoder (that makes the prediction), BERT uses only the encoder.