### PR TITLE
fix "bert_model" outputs

### DIFF
--- a/08.sentiment-analysis-with-bert.ipynb
+++ b/08.sentiment-analysis-with-bert.ipynb
@@ -1563,10 +1563,11 @@
         "colab": {}
       },
       "source": [
-        "last_hidden_state, pooled_output = bert_model(\n",
+        "last_hidden_state_pooled_output = bert_model(\n",
         "  input_ids=encoding['input_ids'], \n",
         "  attention_mask=encoding['attention_mask']\n",
-        ")"
+        ")",
+        "last_hidden_state, pooled_output = last_hidden_state_pooled_output[0], last_hidden_state_pooled_output[1]"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
 (last_hidden_state, pooled_output)
othervise last_hidden_state.shape return an AttributeError: 'str' object has no attribute 'shape'